### PR TITLE
Reporters (Internal and Allure)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 notLoggedInState.json
 loggedInState.json
 
+#Appure ##
+allure-report/
+allure-results/
+
 # Created by https://www.toptal.com/developers/gitignore/api/node,macos
 # Edit at https://www.toptal.com/developers/gitignore?templates=node,macos
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@types/node": "^20.11.13",
         "@typescript-eslint/eslint-plugin": "^7.0.2",
         "@typescript-eslint/parser": "^7.0.2",
+        "allure-commandline": "^2.27.0",
+        "allure-playwright": "^2.13.0",
         "eslint": "^8.56.0",
         "eslint-plugin-playwright": "^1.3.0",
         "prettier": "^3.2.5"
@@ -169,12 +171,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.1.tgz",
-      "integrity": "sha512-9g8EWTjiQ9yFBXc6HjCWe41msLpxEX0KhmfmPl9RPLJdfzL4F0lg2BdJ91O9azFdl11y1pmpwdjBiSxvqc+btw==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
+      "integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.41.1"
+        "playwright": "1.42.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -459,6 +461,55 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/allure-commandline": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/allure-commandline/-/allure-commandline-2.27.0.tgz",
+      "integrity": "sha512-KuxKEZ2Joa0LCcM9w8AWgWJgmB5d3VqSgaJhPC6pEsdRwAObT/JE8NY0u4mJ61+c2mhAPGIetGV9jgP3gzxgIg==",
+      "dev": true,
+      "bin": {
+        "allure": "bin/allure"
+      }
+    },
+    "node_modules/allure-js-commons": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-2.13.0.tgz",
+      "integrity": "sha512-IUT5Lyw+pAUku89Bxp6zltY6DFLYbt6vfpjRxM4Du4wKdPDrFNSPh4iPlKo3+11uctQqO+9xWUq9jH2c6SxKKA==",
+      "dev": true,
+      "dependencies": {
+        "properties": "^1.2.1",
+        "strip-ansi": "^5.2.0"
+      }
+    },
+    "node_modules/allure-js-commons/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/allure-js-commons/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/allure-playwright": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/allure-playwright/-/allure-playwright-2.13.0.tgz",
+      "integrity": "sha512-AlPZWR7Yrc71UkWtKGkmsEFv6NI02KrzjgfVVxjN/fgpUcmYpQKUFnQbzm8/hUeYrALAl6PJfS6kWFsTaBy4Qw==",
+      "dev": true,
+      "dependencies": {
+        "allure-js-commons": "2.13.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -1373,12 +1424,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.1.tgz",
-      "integrity": "sha512-gdZAWG97oUnbBdRL3GuBvX3nDDmUOuqzV/D24dytqlKt+eI5KbwusluZRGljx1YoJKZ2NRPaeWiFTeGZO7SosQ==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
+      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.41.1"
+        "playwright-core": "1.42.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1391,9 +1442,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.1.tgz",
-      "integrity": "sha512-/KPO5DzXSMlxSX77wy+HihKGOunh3hqndhqeo/nMxfigiKzogn8kfL0ZBDu0L1RKgan5XHCPmn6zXd2NUJgjhg==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
+      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -1424,6 +1475,15 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/properties/-/properties-1.2.1.tgz",
+      "integrity": "sha512-qYNxyMj1JeW54i/EWEFsM1cVwxJbtgPp8+0Wg9XjNaK6VE/c4oRi6PNu5p7w1mNXEIQIjV5Wwn8v8Gz82/QzdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "index.js",
   "scripts": {
     "test": "npx playwright test account.spec.ts blog.spec.ts contact.spec.ts home.spec.ts upload.spec.ts",
-    "test:workers4": "npm run test --workers 4"
+    "test:workers4": "npm run test --workers 4",
+    "allure-generate": "npx allure generate allure-results --clean && npx allure open",
+    "allure-clean": "rm -r allure-results/ allure-report",
+    "test:allure": "npm run test && npm run allure-generate && npm run allure-clean"
   },
   "keywords": [],
   "author": "Santiago Bernal",
@@ -16,6 +19,8 @@
     "@types/node": "^20.11.13",
     "@typescript-eslint/eslint-plugin": "^7.0.2",
     "@typescript-eslint/parser": "^7.0.2",
+    "allure-commandline": "^2.27.0",
+    "allure-playwright": "^2.13.0",
     "eslint": "^8.56.0",
     "eslint-plugin-playwright": "^1.3.0",
     "prettier": "^3.2.5"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,8 +11,8 @@ import { defineConfig, devices } from "@playwright/test";
  */
 export default defineConfig({
   testDir: "./tests",
-  // Each test is given 30 seconds.
-  timeout: 30000,
+  // Each test is given 50 seconds.
+  timeout: 50000,
   /* Run tests in files in parallel - if false it will not use workers */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -22,7 +22,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. - if workers are always the same do workers: number */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  reporter: [["allure-playwright"], ["line"]],
 
   globalSetup: require.resolve("./utils/global-setup"),
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -31,7 +31,7 @@ export default defineConfig({
     baseURL: "https://practice.sdetunicorns.com",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer, use "on" to get the trace in the report */
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
     storageState: "loggedInState.json"
   },
 


### PR DESCRIPTION
Tests Passed:
<img width="709" alt="Screen Shot 2024-03-04 at 5 32 41 PM" src="https://github.com/Sanberqui18/playwright-typescript/assets/119998036/6fc63f11-0fad-4d19-9551-beb34cb5496e">
 
Added: 
- Internal reports (HTML, List, Line - Chosen)
- Allure Report
- NPM scripts
- Trace on failure, to get trace in allure reports integrated when a test fails.